### PR TITLE
Customise the script for Esplorio's usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ make
 
 **Note:** If you installed SBShortcutMenuSimulator using the old method, go [here](https://github.com/DeskConnect/SBShortcutMenuSimulator/blob/85c3d73b9e22a20e5c59144fa1b3d19883a68f0e/README.md) and follow the uninstallation directions.
 
+## Quick Setup
+
+For a detailed breakdown of the setup steps, please take a look at the Usage section below, otherwise, do:
+
+- Activate a simulator
+- Add this to your `bash_profile` (please modify `PATH_TO_3D_TOUCH` to whatever is on your machine):
+
+```
+export PATH_TO_3D_TOUCH="~/git/esplorio/SBShortcutMenuSimulator"
+
+alias setup-3d-touch="cd $PATH_TO_3D_TOUCH && xcrun simctl spawn booted launchctl debug system/com.apple.SpringBoard --environment DYLD_INSERT_LIBRARIES=$PWD/SBShortcutMenuSimulator.dylib && xcrun simctl spawn booted launchctl stop com.apple.SpringBoard"
+
+alias 3d-touch="echo 'io.esplor.ios' | nc 127.0.0.1 7007"
+```
+
+- In the command line, run `make` under `PATH_TO_3D_TOUCH`
+- Run `setup-3d-touch` to set up the 3D touch server
+- Run `3d-touch` to make a call to summon the 3D touch menu
+
 ## Usage
 
 First, start SpringBoard with SBShortcutMenuSimulator enabled (run this from the cloned directory):
@@ -28,10 +47,12 @@ xcrun simctl spawn booted launchctl stop com.apple.SpringBoard
 Now, to show an app's quick action menu, send the app's bundle identifier over TCP to port 8000. For example, running this command will show the shortcut menu for Calendar:
 
 ``` sh
-echo 'com.apple.mobilecal' | nc 127.0.0.1 8000
+echo 'com.apple.mobilecal' | nc 127.0.0.1 7007
 ```
 
 <img src="https://raw.githubusercontent.com/DeskConnect/SBShortcutMenuSimulator/screenshot/Shortcuts.png" width="326" height="592"></img>
+
+**NOTICE**: For our own (Esplorio) fork, I have updated the port number from `8000` to `7007` so that we can avoid clashing with the Django server port
 
 ## License
 

--- a/SBShortcutMenuListener.m
+++ b/SBShortcutMenuListener.m
@@ -33,28 +33,28 @@ static void SBShortcutMenuListenerInitialize() {
     struct sockaddr_in server_addr = {};
     server_addr.sin_len = sizeof(server_addr);
     server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(8000);
+    server_addr.sin_port = htons(7007);
     server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    
+
     int sock;
     if ((sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1)
         return;
-    
+
     if (bind(sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1)
         return;
-    
+
     if (listen(sock, 1) == -1)
         return;
-    
+
     server = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, sock, 0, dispatch_get_main_queue());
-    
+
     dispatch_source_set_event_handler(server, ^{
         int client_sock;
         struct sockaddr_in client_addr;
         socklen_t size = sizeof(client_addr);
         if ((client_sock = accept(sock, (struct sockaddr *)&client_addr, &size)) == -1)
             return;
-        
+
         dispatch_io_t channel = dispatch_io_create(DISPATCH_IO_STREAM, client_sock, dispatch_get_main_queue(), ^(int error) {
             close(client_sock);
         });
@@ -62,7 +62,7 @@ static void SBShortcutMenuListenerInitialize() {
         dispatch_io_read(channel, 0, SIZE_MAX, dispatch_get_main_queue(), ^(bool done, dispatch_data_t data, int error) {
             if (done && data == dispatch_data_empty)
                 return dispatch_io_close(channel, DISPATCH_IO_STOP);
-            
+
             if (data && dispatch_data_get_size(data) > 0) {
                 size_t length = 0;
                 const void *bytes = NULL;


### PR DESCRIPTION
Because we develop on Django port 8000, I changed the port this script uses to 7007

I also added new `alias` for our own use case and further instructions for quick setup
